### PR TITLE
Post for the new cohorts release 20260120

### DIFF
--- a/_posts/2026-01-20-ag3-cohorts-v20260120.md
+++ b/_posts/2026-01-20-ag3-cohorts-v20260120.md
@@ -1,0 +1,30 @@
+---
+layout: post
+title:  "Ag3 cohorts analysis version 20260120"
+tags: data
+---
+
+A new cohorts analysis version `20260120` has been released for the
+Ag3 data resource. This is now the default cohorts analysis version
+when using the `malariagen_data` [Ag3
+API](https://malariagen.github.io/malariagen-data-python/latest/Ag3.html). This
+cohorts analysis will be available for datasets up to and including Ag3.17.
+
+Please note that the new cohorts analysis may change the values of
+sample metadata columns including `taxon`, `admin1_iso`,
+`admin1_name`, `admin2_name`, and derived columns beginning `cohorts_`
+relative to previous cohorts analysis versions.
+
+To pin this cohorts analysis when accessing data:
+
+{% highlight python %}
+import malariagen_data
+
+ag3 = malariagen_data.Ag3(
+    cohorts_analysis="20260120",
+)
+{% endhighlight %}
+
+This new version does not introduce any key changes. 
+
+ If you need to access the previous version of the cohorts analysis, you can pin it using the code in [here](https://malariagen.github.io/vobs-updates/2024/10/02/ag3-cohorts-v20250815.html).


### PR DESCRIPTION
Addresses #96.

It is quite plain because no sample changed cohort.

Note: the PR on `vector-ops` https://github.com/malariagen/vector-ops/pull/2690 has not been merged yet.